### PR TITLE
Made time key to use in elastic search queries configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Via command line arguments the following options can be overwritten:
     	The path to listen on for HTTP requests (default "/metrics")
   -port int
     	The port to listen on for HTTP requests (default 8080)
+  -time-key string
+        The time key to use in elastic search queries (default "@timestamp")
 ```
 
 ### Example:

--- a/adapter/cmdlineprovider.go
+++ b/adapter/cmdlineprovider.go
@@ -17,6 +17,7 @@ type CommandLineOption struct {
 	Port                   int
 	Path                   string
 	ElasticsearchQueryFile string
+	TimeKey                string
 }
 
 //ReadCmdLineOptions merge defaults with cmdline parameter
@@ -26,6 +27,7 @@ func (provider *CommandLineOptionProvider) ReadCmdLineOptions() {
 	flag.StringVar(&provider.Options.Path, "path", provider.Options.Path, "The path to listen on for HTTP requests")
 	flag.IntVar(&provider.Options.Freq, "freq", provider.Options.Freq, "The interval in seconds in which to query elastic search")
 	flag.StringVar(&provider.Options.ElasticsearchQueryFile, "elasticqueries", provider.Options.ElasticsearchQueryFile, "The path to the queries.cfg")
+	flag.StringVar(&provider.Options.TimeKey, "time-key", provider.Options.TimeKey, "The time key to use in elastic search queries")
 	flag.Parse()
 }
 
@@ -36,4 +38,5 @@ func (provider *CommandLineOptionProvider) PrintCmdLineOptions() {
 	log.Println("\tFreq:", provider.Options.Freq)
 	log.Println("\tPort:", provider.Options.Port)
 	log.Println("\tElasticsearch Configuration File:", provider.Options.ElasticsearchQueryFile)
+	log.Println("\tTime Key:", provider.Options.TimeKey)
 }

--- a/monitor/monitorexecutor.go
+++ b/monitor/monitorexecutor.go
@@ -15,13 +15,14 @@ type Executor struct {
 }
 
 //BuildMonitors create new Instances form given Monitortype for each query and register all metrics
-func (executor *Executor) BuildMonitors(plainqueries map[string]string, newMonitor func() LogMonitor) {
+func (executor *Executor) BuildMonitors(timeKey string, plainqueries map[string]string, newMonitor func() LogMonitor) {
 	for name, queryBody := range plainqueries {
 		logMonitor := newMonitor()
 		query := Query{
-			Name:   name,
-			filter: queryBody,
-			Exec:   executor.QueryExecution,
+			Name:    name,
+			filter:  queryBody,
+			Exec:    executor.QueryExecution,
+			timeKey: timeKey,
 		}
 
 		metrics := logMonitor.BuildMetrics(query)

--- a/monitor/query.go
+++ b/monitor/query.go
@@ -7,15 +7,17 @@ import (
 
 //Query defines an executable query with name
 type Query struct {
-	Name   string
-	filter string
-	Exec   func(string) (*Hits, error)
+	Name    string
+	filter  string
+	Exec    func(string) (*Hits, error)
+	timeKey string
 }
 
 //BuildBody builds a complete query
 func (query *Query) BuildBody(size string, since time.Time) string {
 	body := strings.Replace(queryTemplate, "<size>", size, 1)
 	body = strings.Replace(body, "<timestamp>", formatTime(since), 1)
+	body = strings.Replace(body, "<time-key>", query.timeKey, 1)
 	return strings.Replace(body, "<query>", query.filter, 1)
 }
 
@@ -33,7 +35,7 @@ const queryTemplate = `{
       },
       "filter": {
         "range": {
-          "@timestamp": {
+          "<time-key>": {
             "gte": "<timestamp>",
             "format": "yyyy-MM-dd HH:mm:ss"
           }


### PR DESCRIPTION
Because of some issues in fluent-bit we have to alter the default Time_Key from `@timestamp` to e.g. `@timestamp-es`:
https://github.com/fluent/fluent-bit/issues/652
https://github.com/fluent/fluent-bit/issues/628
So far Elcep uses hard coded time key `@timestamp` in elastic search queries. With this PR we made this time key configurable.