### PR TITLE
update hash for elcep/main/plugin module 1.2

### DIFF
--- a/main/go.sum
+++ b/main/go.sum
@@ -1,7 +1,7 @@
 github.com/MaibornWolff/elcep/main/config v1.2.0 h1:PJm/Ujl7B8mFNas0mlp4gZQUU14iBvpbPc9uHYpIoBQ=
 github.com/MaibornWolff/elcep/main/config v1.2.0/go.mod h1:8swQ4X4rk6Pkh8DILISmDtfl7QZwCpatZYOKQueIxZI=
-github.com/MaibornWolff/elcep/main/plugin v1.2.0 h1:6r/613i1tIIfjJt4UcNP60lrCHOAVfP0iro29YDdEB0=
-github.com/MaibornWolff/elcep/main/plugin v1.2.0/go.mod h1:TMZ8UAwUyw7VlflSePniOGvNEcTq3drP/CS7aFZo5sE=
+github.com/MaibornWolff/elcep/main/plugin v1.2.0 h1:3j5YvekQasFZb6A3sWujP/YVqJOMrtMZLO1jHeS+0L8=
+github.com/MaibornWolff/elcep/main/plugin v1.2.0/go.mod h1:wojoBeDuzibW8q9BeKGyLoOIP59Zrt2UBe1I4OLQdJw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=

--- a/plugins/bucket/go.sum
+++ b/plugins/bucket/go.sum
@@ -1,7 +1,7 @@
 github.com/MaibornWolff/elcep/main/config v1.2.0 h1:PJm/Ujl7B8mFNas0mlp4gZQUU14iBvpbPc9uHYpIoBQ=
 github.com/MaibornWolff/elcep/main/config v1.2.0/go.mod h1:8swQ4X4rk6Pkh8DILISmDtfl7QZwCpatZYOKQueIxZI=
-github.com/MaibornWolff/elcep/main/plugin v1.2.0 h1:6r/613i1tIIfjJt4UcNP60lrCHOAVfP0iro29YDdEB0=
-github.com/MaibornWolff/elcep/main/plugin v1.2.0/go.mod h1:TMZ8UAwUyw7VlflSePniOGvNEcTq3drP/CS7aFZo5sE=
+github.com/MaibornWolff/elcep/main/plugin v1.2.0 h1:3j5YvekQasFZb6A3sWujP/YVqJOMrtMZLO1jHeS+0L8=
+github.com/MaibornWolff/elcep/main/plugin v1.2.0/go.mod h1:wojoBeDuzibW8q9BeKGyLoOIP59Zrt2UBe1I4OLQdJw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=

--- a/plugins/counter/go.sum
+++ b/plugins/counter/go.sum
@@ -1,7 +1,7 @@
 github.com/MaibornWolff/elcep/main/config v1.2.0 h1:PJm/Ujl7B8mFNas0mlp4gZQUU14iBvpbPc9uHYpIoBQ=
 github.com/MaibornWolff/elcep/main/config v1.2.0/go.mod h1:8swQ4X4rk6Pkh8DILISmDtfl7QZwCpatZYOKQueIxZI=
-github.com/MaibornWolff/elcep/main/plugin v1.2.0 h1:6r/613i1tIIfjJt4UcNP60lrCHOAVfP0iro29YDdEB0=
-github.com/MaibornWolff/elcep/main/plugin v1.2.0/go.mod h1:TMZ8UAwUyw7VlflSePniOGvNEcTq3drP/CS7aFZo5sE=
+github.com/MaibornWolff/elcep/main/plugin v1.2.0 h1:3j5YvekQasFZb6A3sWujP/YVqJOMrtMZLO1jHeS+0L8=
+github.com/MaibornWolff/elcep/main/plugin v1.2.0/go.mod h1:wojoBeDuzibW8q9BeKGyLoOIP59Zrt2UBe1I4OLQdJw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=


### PR DESCRIPTION
The cryptographic hash for code authentication in the go.sum files has changed for the elcep/main/plugin module 1.2.
So currently go build fails.
This changed proviedes an updated hash which fixes this problem.