### PR TITLE
Allow "Kubernetes-Style" labels for aggregation

### DIFF
--- a/plugins/bucket/bucket_aggregation_monitor.go
+++ b/plugins/bucket/bucket_aggregation_monitor.go
@@ -44,6 +44,7 @@ func (monitor *bucketAggregationMonitor) processAggregations(
 		monitor.updateCounter(hits, labels)
 		return
 	}
+	expectedAggregations = getOriginalAggregationKeys(expectedAggregations)
 	if buckets, ok := container.Terms(expectedAggregations[0]); !ok {
 		log.Printf("Missing terms aggregation %s in response %v\n", expectedAggregations[0], container)
 	} else {
@@ -67,7 +68,7 @@ func (monitor *bucketAggregationMonitor) updateCounter(newCount int64, labels pr
 
 func withLabel(labels prometheus.Labels, key string, value string) prometheus.Labels {
 	newLabels := prometheus.Labels{
-		key: value,
+		getAllowedPrometheusLabel(key): value,
 	}
 	for k, v := range labels {
 		newLabels[k] = v

--- a/plugins/bucket/go.mod
+++ b/plugins/bucket/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/MaibornWolff/elcep/main/plugin v1.2.0
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/olivere/elastic v6.2.19+incompatible
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.0.0
 )

--- a/plugins/bucket/go.sum
+++ b/plugins/bucket/go.sum
@@ -33,6 +33,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/olivere/elastic v6.2.19+incompatible h1:FYiohzobKD2tib3sHgEHNBSzcw1onqApaumIBBstchQ=
 github.com/olivere/elastic v6.2.19+incompatible/go.mod h1:J+q1zQJTgAz9woqsbVRqGeB5G1iqDKVBWLNSYW8yfJ8=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/plugins/bucket/main.go
+++ b/plugins/bucket/main.go
@@ -4,9 +4,13 @@ import (
 	"github.com/MaibornWolff/elcep/main/config"
 	"github.com/MaibornWolff/elcep/main/plugin"
 	"github.com/olivere/elastic"
+	"github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"log"
+	"time"
 )
+
+var bucketCache = cache.New(cache.NoExpiration, 60*time.Minute)
 
 // The factory method for the plugin
 // noinspection GoUnusedExportedFunction


### PR DESCRIPTION
/cc @xellsys @christle 

After deep investigating, i found  that Prometheus labels could not contain special characters.  
[metric-names-and-labels](https://prometheus.io/docs/concepts/data_model/#metric-names-and-labels)

So, the problem is with Prometheus client library.

I had the idea to replace special chars with the allowed  underscore `_`.

but, i could not retrieve buckets after registration to the client, that´s why i store the origin labels in the cache.


Fixes #34 
Will Fixes #29 as well