### PR TITLE
ci: add SBOM generation workflow

### DIFF
--- a/.github/workflows/create_sbom.yml
+++ b/.github/workflows/create_sbom.yml
@@ -1,0 +1,34 @@
+name: Generate SBOM
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: main/go.mod
+
+      - name: Generate SBOM
+        uses: CycloneDX/gh-gomod-generate-sbom@efc74245d6802c8cefd925620515442756c70d8f # v2.0.0
+        with:
+          version: v1
+          args: mod -licenses -json -output bom.json ./main/
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom-cyclonedx
+          path: bom.json


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow (`create_sbom.yml`) that generates a CycloneDX JSON SBOM from Go modules
- Uses `CycloneDX/gh-gomod-generate-sbom` v2 with license detection enabled
- Runs on push and PR to `master`, uploads the SBOM as a build artifact

## Details
- SBOM format: CycloneDX JSON
- Tool: [cyclonedx-gomod](https://github.com/CycloneDX/cyclonedx-gomod) via the official GitHub Action
- All action references are pinned to full commit SHAs for supply chain security
- Go version is derived from `main/go.mod`

## Test plan
- [ ] Verify the workflow runs successfully on the PR
- [ ] Check that the `sbom-cyclonedx` artifact is produced and contains valid CycloneDX JSON

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Software Bill of Materials (SBOM) generation to enhance supply chain security and transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->